### PR TITLE
Fedora latest stable version Docker image

### DIFF
--- a/Dockerfile.fedora-latest
+++ b/Dockerfile.fedora-latest
@@ -1,0 +1,21 @@
+# Dockerfile for latest Fedora version
+
+FROM fedora:latest
+
+RUN dnf -y install bash \
+    bzip2 \
+    curl \
+    git \
+    gcc-gnat \
+    gprbuild \
+    make \
+    mercurial \
+    python3 \
+    python3-devel \
+    python3-pip \
+    subversion \
+    sudo \
+    unzip \
+    wget \
+    fakeroot
+


### PR DESCRIPTION
A Docker image which put in place a Docker image based on latest stable Fedora version (currently Fedora 33).