### PR TITLE
Add Docker images for openSUSE releases

### DIFF
--- a/Dockerfile.opensuse-leap-latest
+++ b/Dockerfile.opensuse-leap-latest
@@ -1,0 +1,40 @@
+# Dockerfile for latest openSUSE Leap release
+
+FROM opensuse/leap:latest
+
+ENV PATH=/opt/gprbuild/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN zypper --non-interactive update zypper && \
+    zypper --non-interactive --no-refresh update && \
+    zypper --non-interactive --no-refresh install \
+        bzip2 \
+        curl \
+        gcc-ada \
+        git-core \
+        gzip \
+        make \
+        mercurial \
+        python3 \
+        python3-devel \
+        python3-pip \
+        subversion \
+        sudo \
+        tar \
+        unzip \
+        wget \
+        fakeroot && \
+\
+    # GPRbuild via alr
+    mkdir /tmp/zzz-alr && \
+    wget -O /tmp/zzz-alr/alr.zip \
+        https://github.com/alire-project/alire/releases/download/v1.2.1/alr-1.2.1-bin-x86_64-linux.zip && \
+    unzip /tmp/zzz-alr/alr.zip -d /tmp/zzz-alr && \
+    cp /tmp/zzz-alr/bin/alr /usr/bin/alr && \
+    rm -rf /tmp/zzz-alr && \
+    chmod +x /usr/bin/alr && \
+    alr toolchain --install gprbuild --install-dir /opt && \
+    rm /usr/bin/alr && \
+    rm -rf /root/.config/alire && \
+    mv /opt/gprbuild* /opt/gprbuild && \
+    wget -O /opt/gprbuild/share/gprconfig/compilers.xml \
+        https://github.com/AdaCore/gprconfig_kb/raw/master/db/compilers.xml

--- a/Dockerfile.opensuse-tumbleweed-latest
+++ b/Dockerfile.opensuse-tumbleweed-latest
@@ -1,0 +1,39 @@
+# Dockerfile for latest openSUSE Tumbleweed release
+
+FROM opensuse/tumbleweed:latest
+
+ENV PATH=/opt/gprbuild/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN zypper --non-interactive dist-upgrade && \
+    zypper --non-interactive --no-refresh install \
+        bzip2 \
+        gcc-ada \
+        git-core \
+        gzip \
+        make \
+        mercurial \
+        python3 \
+        python3-devel \
+        python3-pip \
+        subversion \
+        sudo \
+        tar \
+        unzip \
+        wget \
+        fakeroot && \
+\
+    # GPRbuild via alr
+    mkdir /tmp/zzz-alr && \
+    wget -O /tmp/zzz-alr/alr.zip \
+        https://github.com/alire-project/alire/releases/download/v1.2.1/alr-1.2.1-bin-x86_64-linux.zip && \
+    unzip /tmp/zzz-alr/alr.zip -d /tmp/zzz-alr && \
+    cp /tmp/zzz-alr/bin/alr /usr/bin/alr && \
+    rm -rf /tmp/zzz-alr && \
+    chmod +x /usr/bin/alr && \
+    chmod u+w /opt && \
+    alr toolchain --install gprbuild --install-dir /opt && \
+    rm /usr/bin/alr && \
+    rm -rf /root/.config/alire && \
+    mv /opt/gprbuild* /opt/gprbuild && \
+    wget -O /opt/gprbuild/share/gprconfig/compilers.xml \
+        https://github.com/AdaCore/gprconfig_kb/raw/master/db/compilers.xml


### PR DESCRIPTION
Add Docker images for the latest openSUSE Leap and openSUSE Tumbleweed releases. This pull request was created in response to a [comment](https://github.com/alire-project/alire/pull/1173#issuecomment-1243550237) from @mosteo.

The images include the GNAT compiler from the `gcc-ada` package in the openSUSE repositories. Because GPRbuild is not available in the openSUSE repositories, GPRbuild is installed via `alr`. The images also include the latest `compilers.xml` from AdaCore's GPRCONFIG KB so that GPRbuild can find the runtimes that are installed under /usr/**lib64**/gcc/x86_64-suse-linux/**$(gcc -dumpversion)**/adalib rather than /usr/**lib**/gcc/x86_64-suse-linux/**$(gcc -dumpfullversion)**/adalib.